### PR TITLE
Changed summary attribute to properly display 'b' value for simple linea...

### DIFF
--- a/lib/statsample/regression/simple.rb
+++ b/lib/statsample/regression/simple.rb
@@ -110,7 +110,7 @@ module Statsample
             t.row [_("r"), f % r]
             t.row [_("r^2"), f % r2]
             t.row [_("a"), f % a]
-            t.row [_("b"), f % a]
+            t.row [_("b"), f % b]
             t.row [_("s.e"), f % standard_error]
           end
         end


### PR DESCRIPTION
currently displays 'a' value for 'b' value in summary attribute for simple regression
