### PR TITLE
Remove bad check in cronbach_alpha calculation

### DIFF
--- a/lib/statsample/reliability.rb
+++ b/lib/statsample/reliability.rb
@@ -5,7 +5,6 @@ module Statsample
       # only uses tuples without missing data
       def cronbach_alpha(ods)
         ds=ods.dup_only_valid
-        return nil if ds.vectors.any? {|k,v| v.variance==0}
         n_items=ds.fields.size
         return nil if n_items<=1
         s2_items=ds.vectors.inject(0) {|ac,v|


### PR DESCRIPTION
There is no reason to return nil if a single vector has a 0 variance.  For example, let's say you are giving a test, and every single taker gets the easiest question correct.  The variance for that question vector is 0, but Cronbach's alpha can still be calculated correctly for the entire dataset.