### PR TITLE
Raising in equality precludes working with AwesomePrint

### DIFF
--- a/lib/statsample/vector.rb
+++ b/lib/statsample/vector.rb
@@ -219,7 +219,7 @@ module Statsample
     # Vector equality.
     # Two vector will be the same if their data, missing values, type, labels are equals
     def ==(v2)
-      raise TypeError,"Argument should be a Vector" unless v2.instance_of? Statsample::Vector
+      return false unless v2.instance_of? Statsample::Vector
       @data==v2.data and @missing_values==v2.missing_values and @type==v2.type and @labels==v2.labels
     end
     

--- a/test/test_vector.rb
+++ b/test/test_vector.rb
@@ -352,6 +352,7 @@ class StatsampleTestVector < MiniTest::Unit::TestCase
     v1=[1,2,3].to_vector()
     v2=[1,2,3].to_vector()
     assert_equal(v1,v2)
+    assert_equal(false, v1 == Object.new)
   end
   def test_vector_percentil
     a=[1,2,2,3,4,5,5,5,6,10].to_scale


### PR DESCRIPTION
Second comparison of this method in awesome_print/formatter.rb causes
the crash.

Without this fix, pry + awesome_print cannot be used, as even a simple
case such as

```
[1, 2, 3].to_scale
```

will crash

awesome_print/formatter.rb
    # Catch all method to format an arbitrary object.
    #------------------------------------------------------------------------------
    def awesome_self(object, type)
      if @options[:raw] && object.instance_variables.any?
        awesome_object(object)
      elsif object == ENV
        awesome_hash(object.to_hash)
      else
        colorize(object.inspect.to_s, type)
      end
    end
