### PR TITLE
Prevent FloatDomainError on Histogram with span=0

### DIFF
--- a/lib/statsample.rb
+++ b/lib/statsample.rb
@@ -241,7 +241,7 @@ module Statsample
       min = reverse ? e : s
       max = reverse ? s : e
       span=max-min
-      return [s, e] if (!span or (span.respond_to? :infinite? and span.infinite?))
+      return [s, e] if (span == 0 or (span.respond_to? :infinite? and span.infinite?))
       
       step=10**((Math::log(span).quo(Math::log(10))).round - 1).to_f  
       out=[(min.quo(step)).floor * step, (max.quo(step)).ceil * step]

--- a/test/test_histogram.rb
+++ b/test/test_histogram.rb
@@ -100,6 +100,13 @@ class StatsampleHistogramTestCase < MiniTest::Unit::TestCase
       assert_equal(2,h.sum(1,4))
 
     end
+    should "not raise exception when all values equal" do
+      assert_nothing_raised do
+        a = [5,5,5,5,5,5].to_scale
+        h=Statsample::Graph::Histogram.new(a)
+        h.to_svg
+      end
+    end
     
   end
 end


### PR DESCRIPTION
If a Histogram is created with a set of equal values (e.g., [3,3,3]) a `FloatDomainError: -Infinity` error will be raised when calling `to_svg`. This happens because the span calculated in `Statsample::Util#nice` is 0 (see stacktrace below).

It appears that the original code may have been guarding against this by testing `!span`, but this is incorrect and should be tested as `span == 0`. (This may have been a check against `nil` and not zero, but there are better ways to handle that (e.g., `span.nil?`) and it also seems that span could not be `nil` due to the lines of code immediately above, which would raise an error if either `s` or `e` were `nil`.)

```
FloatDomainError: -Infinity
    /Users/ryan/workspace/statsample/lib/statsample.rb:246:in `round'
    /Users/ryan/workspace/statsample/lib/statsample.rb:246:in `nice'
    /Users/ryan/workspace/statsample/lib/statsample/vector.rb:1004:in
    `histogram'
    /Users/ryan/workspace/statsample/lib/statsample/graph/histogram.rb:77:in
    `pre_vis'
    /Users/ryan/workspace/statsample/lib/statsample/graph/histogram.rb:107:in
    `rubyvis_panel'
    /Users/ryan/workspace/statsample/lib/statsample/graph/histogram.rb:177:in
    `to_svg'
```
