### PR TITLE
remove Daru deprecation warnings for multiple regression

### DIFF
--- a/lib/statsample/bivariate.rb
+++ b/lib/statsample/bivariate.rb
@@ -154,7 +154,7 @@ module Statsample
       
       def covariance_matrix(ds)
         vars,cases=ds.fields.size,ds.cases
-        if !ds.has_missing_data? and Statsample.has_gsl? and prediction_optimized(vars,cases) < prediction_pairwise(vars,cases)
+        if !ds.include_values? and Statsample.has_gsl? and prediction_optimized(vars,cases) < prediction_pairwise(vars,cases)
           cm=covariance_matrix_optimized(ds)
         else
           cm=covariance_matrix_pairwise(ds)
@@ -190,7 +190,7 @@ module Statsample
       # Order of rows and columns depends on Dataset#fields order
       def correlation_matrix(ds)
         vars,cases=ds.fields.size,ds.cases
-        if !ds.has_missing_data? and Statsample.has_gsl? and prediction_optimized(vars,cases) < prediction_pairwise(vars,cases)
+        if !ds.include_values? and Statsample.has_gsl? and prediction_optimized(vars,cases) < prediction_pairwise(vars,cases)
           cm=correlation_matrix_optimized(ds)
         else
           cm=correlation_matrix_pairwise(ds)
@@ -233,7 +233,7 @@ module Statsample
       def n_valid_matrix(ds)
         ds.collect_matrix do |row,col|
           if row==col
-            ds[row].valid_data.size
+            ds[row].reject_values.size
           else
             rowa,rowb=Statsample.only_valid_clone(ds[row],ds[col])
             rowa.size

--- a/lib/statsample/regression.rb
+++ b/lib/statsample/regression.rb
@@ -58,7 +58,7 @@ module Statsample
           if Statsample.has_gsl? and false
             Statsample::Regression::Multiple::GslEngine.new(ds, y_var, opts)
           else
-            ds2=ds.dup_only_valid
+            ds2=ds.reject_values
             Statsample::Regression::Multiple::RubyEngine.new(ds2,y_var, opts)
           end
         end

--- a/lib/statsample/regression/multiple/rubyengine.rb
+++ b/lib/statsample/regression/multiple/rubyengine.rb
@@ -30,7 +30,7 @@ class RubyEngine < MatrixEngine
     super(matrix, y_var, opts)
     @ds=ds
     @dy=ds[@y_var]
-    @ds_valid=ds.dup_only_valid
+    @ds_valid=ds.reject_values
     @total_cases=@ds.cases
     @valid_cases=@ds_valid.cases
     @ds_indep = ds.dup(ds.fields-[y_var])


### PR DESCRIPTION
This removes the deprecation warnings on the following methods for `Daru` data frames and vectors:

- `Daru::DataFrame#has_missing_data?` is now `#include_values?`
- `Daru::DataFrame#dup_only_valid` is now `#reject_values?`
- `Daru::Vector#valid_data` is now `#reject_values`

I'm mainly using `Statsample::Regression::Multiple` and got deprecation warnings that point to these lines of code.

Hope you can take a look and would like some recommendations where `Daru` deprecated methods are also used.